### PR TITLE
简化客户端调用方式

### DIFF
--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/XDConfigData.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/XDConfigData.java
@@ -1,0 +1,107 @@
+package io.github.xdiamond.client;
+
+import io.github.xdiamond.common.ResolvedConfigVO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * config value container
+ *
+ * @author fxltsbl3855
+ *
+ */
+public class XDConfigData {
+    private static final Logger logger = LoggerFactory.getLogger(XDConfigData.class);
+    private static XDConfigData ourInstance = new XDConfigData();
+    private ConcurrentHashMap<String,String> datamap = new ConcurrentHashMap<String,String>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+
+    public static XDConfigData getIns() {
+        return ourInstance;
+    }
+
+    private XDConfigData() {
+    }
+
+
+
+    public  String getValue(String key)  {
+        lock.readLock().lock();
+        try {
+            if(!datamap.containsKey(key)){
+                return null;
+            }
+            return datamap.get(key);
+        }finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void transData(Map<String, ResolvedConfigVO> voMap){
+        lock.writeLock().lock();
+        try {
+            this.datamap.clear();
+            if(voMap != null && voMap.size() > 0) {
+                for (Map.Entry<String, ResolvedConfigVO> entry : voMap.entrySet()) {
+                    this.datamap.put(entry.getValue().getConfig().getKey(), entry.getValue().getConfig().getValue());
+                }
+            }
+        }finally {
+            lock.writeLock().unlock();
+        }
+        logger.debug("current config data is : {}",toString());
+    }
+
+    public void putValue(String key,String value){
+        lock.readLock().lock();
+        try {
+            datamap.put(key,value);
+        }finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void updateValue(String key,String value){
+        lock.readLock().lock();
+        try {
+            if(!datamap.containsKey(key)) {
+                logger.error("update key,but not find key,key="+key);
+                return;
+            }
+            datamap.put(key,value);
+        }finally {
+            lock.readLock().unlock();
+        }
+
+    }
+    public String delValue(String key){
+        lock.readLock().lock();
+        try {
+            return datamap.remove(key);
+        }finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public String toString(){
+        if(datamap.size() == 0){
+            return "empty map";
+        }
+        StringBuilder sb = new StringBuilder();
+        for(Map.Entry entry : datamap.entrySet()){
+            sb.append(entry.getKey());
+            sb.append("=");
+            sb.append(entry.getValue());
+            sb.append(", ");
+        }
+        return sb.toString();
+    }
+}

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/XDConfigUtil.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/XDConfigUtil.java
@@ -1,0 +1,62 @@
+package io.github.xdiamond.client;
+
+import io.github.xdiamond.client.exception.XDException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * API for app user invoke.
+ * e.g
+ * Integer taskInterval = XDConfigUtil.get("task.interval",Integer.class);
+ * Integer taskInterval2 = XDConfigUtil.get("task.interval",Integer.class,15);
+ * String logLevel = XDConfigUtil.get("log.level");
+ * String logLevel2 = XDConfigUtil.get("log.level","INFO");
+ *
+ * @author fxltsbl3855
+ *
+ */
+public class XDConfigUtil {
+    private static final Logger logger = LoggerFactory.getLogger(XDConfigUtil.class);
+
+    public static <T> T get(String key,Class<T> clazz){
+        String value = get(key,"");
+        if (String.class == clazz) {
+            return (T) value;
+        } else if (Integer.class == clazz || int.class == clazz) {
+            return (T) Integer.valueOf(value);
+        } else if (Long.class == clazz || long.class == clazz) {
+            return (T) Long.valueOf(value);
+        } else if (Double.class == clazz || double.class == clazz) {
+            return (T) Double.valueOf(value);
+        } else if (Short.class == clazz || short.class == clazz) {
+            return (T) Short.valueOf(value);
+        } else {
+            return (T) value;
+        }
+    }
+
+    public static <T> T get(String key,Class<T> clazz,T t){
+        try {
+            return get(key,clazz);
+        }catch (Exception e){
+            logger.error("get error",e);
+            return t;
+        }
+    }
+
+    public static String get(String key) {
+       return get(key,"");
+    }
+
+    public static String get(String key,String defaultValueWhenError) {
+        try {
+            return XDConfigData.getIns().getValue(key);
+        }catch (Exception e){
+            logger.error("get config error",e);
+            return defaultValueWhenError;
+        }
+    }
+}

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/XDiamondConfig.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/XDiamondConfig.java
@@ -127,6 +127,7 @@ public class XDiamondConfig {
         List<ResolvedConfigVO> resolvedConfigs = configFuture.get(10, TimeUnit.SECONDS);
         if (configFuture.isSuccess()) {
           loadConfig(resolvedConfigs);
+          XDConfigData.getIns().transData(this.resolvedConfigVOMap);
           logger.info("load config from xdiamond server success. " + toProjectInfoString());
           bShouldLoadLocalConfig = false;
 
@@ -147,6 +148,7 @@ public class XDiamondConfig {
       try {
         List<ResolvedConfigVO> resolvedConfigVOList = loadLocalConfig();
         this.resolvedConfigVOMap = ResolvedConfigVO.listToMap(resolvedConfigVOList);
+        XDConfigData.getIns().transData(this.resolvedConfigVOMap);
         logger.info("load xdiamond config " + toProjectInfoString() + " from localConfigPath:"
             + localConfigPath);
 

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/exception/XDException.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/exception/XDException.java
@@ -1,0 +1,27 @@
+package io.github.xdiamond.client.exception;
+
+/**
+ * Created with IntelliJ IDEA.
+ *
+ * @author fxltsbl3855
+ *      XDiamond Exception
+ */
+public class XDException extends Exception {
+
+    public XDException(){
+        super();
+    }
+
+    public XDException(String msg){
+        super(msg);
+    }
+
+    public XDException(String msg, Throwable t){
+        super(msg,t);
+    }
+
+    public XDException(Throwable t){
+        super(t);
+    }
+}
+

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/listener/ConfigListener.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/listener/ConfigListener.java
@@ -1,0 +1,31 @@
+package io.github.xdiamond.client.listener;
+
+import io.github.xdiamond.client.XDConfigData;
+import io.github.xdiamond.client.annotation.AllKeyListener;
+import io.github.xdiamond.client.event.ConfigEvent;
+import io.github.xdiamond.client.event.EventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * properties listener
+ *
+ * @author fxltsbl3855
+ */
+@Component
+class ConfigListener {
+    private static final Logger logger = LoggerFactory.getLogger(ConfigListener.class);
+
+    @AllKeyListener
+    public void allKeyListener(ConfigEvent event) {
+        logger.debug("allKeyListener triggered ,key : {}, oldValue : {}, newValue : {}",event.getKey() ,event.getOldValue(),event.getKey());
+        if(event.getEventType() == EventType.ADD){
+            XDConfigData.getIns().putValue(event.getKey(),event.getValue());
+        }else if(event.getEventType() == EventType.DELETE){
+            XDConfigData.getIns().delValue(event.getKey());
+        }else if(event.getEventType() == EventType.UPDATE){
+            XDConfigData.getIns().updateValue(event.getKey(),event.getValue());
+        }
+    }
+}

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/spring/PropertyUtils.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/spring/PropertyUtils.java
@@ -1,0 +1,37 @@
+package io.github.xdiamond.client.spring;
+
+/**
+ * properties file tool
+ *
+ * @author fxltsbl3855
+ *
+ */
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.util.Properties;
+
+public class PropertyUtils {
+    private static final Logger logger = LoggerFactory.getLogger(PropertyUtils.class);
+
+    public static Properties getProperties(String filename) {
+        FileInputStream fis = null;
+        Properties p = new Properties();
+        try {
+            fis = new FileInputStream(filename);
+            p.load(fis);
+        }catch (Exception e) {
+            logger.error("read properties file error",e);
+        }finally {
+            if(fis != null) {
+                try {
+                    fis.close();
+                }catch (Exception e) {
+                    logger.error("close properties file error",e);
+                }
+            }
+        }
+        return p;
+    }
+}

--- a/xdiamond-client/src/main/java/io/github/xdiamond/client/spring/XDConfigLoader.java
+++ b/xdiamond-client/src/main/java/io/github/xdiamond/client/spring/XDConfigLoader.java
@@ -1,0 +1,52 @@
+package io.github.xdiamond.client.spring;
+
+import io.github.xdiamond.client.XDConfigData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
+import org.springframework.core.io.Resource;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * load config properties to container
+ *
+ * @author fxltsbl3855
+ *
+ */
+public class XDConfigLoader extends PropertyPlaceholderConfigurer {
+    private static final Logger logger = LoggerFactory.getLogger(XDConfigLoader.class);
+    protected Resource[] locations;
+
+    public void loadDataToXDConfig(){
+        if(locations == null || locations.length == 0){
+            logger.info("properties file is empty.");
+            return;
+        }
+        for(Resource location : locations){
+            try {
+                Properties prop = PropertyUtils.getProperties(location.getFile().getAbsolutePath());
+                for(Map.Entry entry : prop.entrySet()){
+                    XDConfigData.getIns().putValue(entry.getKey().toString(),entry.getValue().toString());
+                }
+            } catch (Exception e) {
+                logger.error("loadDataToXDConfig error",e);
+            }
+        }
+    }
+
+    @Override
+    public void setLocations(Resource[] locations) {   //由于location是父类私有，所以需要记录到本类的locations中
+        super.setLocations(locations);
+        this.locations = locations;
+        loadDataToXDConfig();
+    }
+
+    @Override
+    public void setLocation(Resource location) {   //由于location是父类私有，所以需要记录到本类的locations中
+        super.setLocation(location);
+        this.locations = new Resource[]{location};
+    }
+
+}


### PR DESCRIPTION
简化客户端调用方式。用户从配置中心获取动态参数时，只需要如下调用即可（不需要注入任何对象）：
String logLevel = XDConfigUtil.get("log.level");
String logLevel2 = XDConfigUtil.get("log.level","INFO");
Integer taskInterval = XDConfigUtil.get("task.interval",Integer.class);
Integer taskInterval2 = XDConfigUtil.get("task.interval",Integer.class,10);

用户在使用时，xdiamond-client.xml文件中properties文件加载类，需要指定为io.github.xdiamond.client.spring.XDConfigLoader即可（主要是针对本地环境或测试环境临时加参数时，只需要在本地properties文件中加入临时参数）。

